### PR TITLE
Validaciones de campos de formularios

### DIFF
--- a/routes/autenticacion.js
+++ b/routes/autenticacion.js
@@ -17,6 +17,10 @@ module.exports = (router) => {
 
         // Cuerpo de la peticion
         const body = req.body;
+        
+        //Juan David: En general, salvo que tengas la necesidad de contrastar información con respecto a la BD, es mejor hacer 
+        //las validaciones de campos vacios directamente desde el formulario en el front. Más aun, es buena idea que no se le
+        //permita al usuario enviar los datos sin que estén completos.
 
         if (!body.email) { // Revisa que se haya ingresado un correo
             res.json({


### PR DESCRIPTION
Es bueno limitar el envío de peticiones a las cosas que son estrictamente necesarias para no generar más tráfico en el servidor. En particular, las validaciones de formato y completitud de los campos se pueden hacer desde el cliente, de forma que en el back solo se procese lo que está directamente relacionado con la BD.